### PR TITLE
fix: inconsistent DeepSeek V3 capitalization in v25.05

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -319,7 +319,7 @@ for more details.
   - Llama3.1 405B
   - Grok1 314B
   - Nemotron4 15B/340B
-  - Deepseek v3
+  - DeepSeek V3
   - Llama 4 Maverick
 - Nemotron-H 56B model training recipe for H100 GPUs
 - End to end installer and launcher for all recipes


### PR DESCRIPTION
This PR addresses the following issue in `CHANGELOG`: inconsistent DeepSeek V3 capitalization in v25.05.

## Changes
- `CHANGELOG`: inconsistent DeepSeek V3 capitalization in v25.05.

## Details
```diff
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,3 @@
-  - Nemotron4 15B/340B
-  - Deepseek v3
-  - Llama 4 Maverick
+  - Nemotron4 15B/340B
+  - DeepSeek V3
+  - Llama 4 Maverick
```

## Tests
- `tests/test_changelog.py`

```diff
--- /dev/null
+++ b/tests/test_changelog.py
@@ -0,0 +1,10 @@
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parent.parent / "CHANGELOG"
+
+def test_v25_05_deepseek_v3_capitalization():
+    text = CHANGELOG.read_text(encoding="utf-8")
+    assert "Deepseek v3" not in text, "Inconsistent 'Deepseek v3' capitalization found in CHANGELOG"
+    section = text.split("## [v25.05]")[1].split("## [")[0]
+    assert "  - DeepSeek V3\n" in section, "v25.05 recipe list should include standardized 'DeepSeek V3'"
```